### PR TITLE
Update package validation baseline to 1.5.1

### DIFF
--- a/src/Pure.Primitives.String.Operations/Pure.Primitives.String.Operations.csproj
+++ b/src/Pure.Primitives.String.Operations/Pure.Primitives.String.Operations.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>1.5.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.5.1</PackageValidationBaselineVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Pure.Primitives" Version="3.6.5" />


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `1.5.0` to `1.5.1` following the successful publish.